### PR TITLE
Added OLLAMA_KEEPALIVE

### DIFF
--- a/api/types.go
+++ b/api/types.go
@@ -436,9 +436,6 @@ func (d *Duration) UnmarshalJSON(b []byte) (err error) {
 			d.Duration = time.Duration(t * float64(time.Second))
 		}
 	case string:
-		if t == "" {
-			return nil
-		}
 		if err = d.FromString(t); err != nil {
 			return err
 		}

--- a/api/types.go
+++ b/api/types.go
@@ -404,6 +404,17 @@ type Duration struct {
 	time.Duration
 }
 
+func (d *Duration) ParseDurationString(t string) error {
+	var err error
+	d.Duration, err = time.ParseDuration(t)
+	if err != nil {
+		return err
+	}
+	if d.Duration < 0 {
+		d.Duration = time.Duration(math.MaxInt64)
+	}
+	return nil
+}
 func (d *Duration) UnmarshalJSON(b []byte) (err error) {
 	var v any
 	if err := json.Unmarshal(b, &v); err != nil {
@@ -420,12 +431,8 @@ func (d *Duration) UnmarshalJSON(b []byte) (err error) {
 			d.Duration = time.Duration(t * float64(time.Second))
 		}
 	case string:
-		d.Duration, err = time.ParseDuration(t)
-		if err != nil {
+		if err = d.ParseDurationString(t); err != nil {
 			return err
-		}
-		if d.Duration < 0 {
-			d.Duration = time.Duration(math.MaxInt64)
 		}
 	}
 

--- a/api/types.go
+++ b/api/types.go
@@ -415,6 +415,11 @@ func (d *Duration) ParseDurationString(t string) error {
 	}
 	return nil
 }
+
+func (d *Duration) MarshalJSON() ([]byte, error) {
+	return json.Marshal(d.String())
+}
+
 func (d *Duration) UnmarshalJSON(b []byte) (err error) {
 	var v any
 	if err := json.Unmarshal(b, &v); err != nil {

--- a/api/types.go
+++ b/api/types.go
@@ -404,9 +404,9 @@ type Duration struct {
 	time.Duration
 }
 
-func (d *Duration) ParseDurationString(t string) error {
+func (d *Duration) FromString(s string) error {
 	var err error
-	d.Duration, err = time.ParseDuration(t)
+	d.Duration, err = time.ParseDuration(s)
 	if err != nil {
 		return err
 	}
@@ -436,7 +436,10 @@ func (d *Duration) UnmarshalJSON(b []byte) (err error) {
 			d.Duration = time.Duration(t * float64(time.Second))
 		}
 	case string:
-		if err = d.ParseDurationString(t); err != nil {
+		if t == "" {
+			return nil
+		}
+		if err = d.FromString(t); err != nil {
 			return err
 		}
 	}

--- a/api/types_test.go
+++ b/api/types_test.go
@@ -1,0 +1,58 @@
+package api
+
+import (
+	"encoding/json"
+	"math"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestKeepAliveParsing(t *testing.T) {
+	tests := []struct {
+		name string
+		req  *ChatRequest
+		exp  *Duration
+	}{
+		{
+			name: "Positive Duration",
+			req: &ChatRequest{
+				KeepAlive: &Duration{Duration: 42 * time.Minute},
+			},
+			exp: &Duration{42 * time.Minute},
+		},
+		{
+			name: "Negative Duration",
+
+			req: &ChatRequest{
+				KeepAlive: &Duration{Duration: -1 * time.Minute},
+			},
+			exp: &Duration{math.MaxInt64},
+		},
+	}
+
+	t.Run("Default", func(t *testing.T) {
+		ser := `{ "keep_alive": "" }`
+
+		var dec ChatRequest
+		err := json.Unmarshal([]byte(ser), &dec)
+		require.NoError(t, err)
+
+		assert.Equal(t, &Duration{5 * time.Minute}, dec.KeepAlive)
+	})
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ser, err := json.Marshal(test.req)
+			require.NoError(t, err)
+
+			var dec ChatRequest
+			err = json.Unmarshal([]byte(ser), &dec)
+			require.NoError(t, err)
+
+			assert.Equal(t, test.exp, dec.KeepAlive)
+		})
+	}
+}

--- a/api/types_test.go
+++ b/api/types_test.go
@@ -25,7 +25,6 @@ func TestKeepAliveParsingFromStruct(t *testing.T) {
 		},
 		{
 			name: "Negative Duration",
-
 			req: &ChatRequest{
 				KeepAlive: &Duration{Duration: -1 * time.Minute},
 			},

--- a/api/types_test.go
+++ b/api/types_test.go
@@ -33,16 +33,6 @@ func TestKeepAliveParsing(t *testing.T) {
 		},
 	}
 
-	t.Run("Default", func(t *testing.T) {
-		ser := `{ "keep_alive": "" }`
-
-		var dec ChatRequest
-		err := json.Unmarshal([]byte(ser), &dec)
-		require.NoError(t, err)
-
-		assert.Equal(t, &Duration{5 * time.Minute}, dec.KeepAlive)
-	})
-
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			ser, err := json.Marshal(test.req)

--- a/api/types_test.go
+++ b/api/types_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestKeepAliveParsing(t *testing.T) {
+func TestKeepAliveParsingFromStruct(t *testing.T) {
 	tests := []struct {
 		name string
 		req  *ChatRequest
@@ -40,6 +40,44 @@ func TestKeepAliveParsing(t *testing.T) {
 
 			var dec ChatRequest
 			err = json.Unmarshal([]byte(ser), &dec)
+			require.NoError(t, err)
+
+			assert.Equal(t, test.exp, dec.KeepAlive)
+		})
+	}
+}
+func TestKeepAliveParsingFromJSON(t *testing.T) {
+	tests := []struct {
+		name string
+		req  string
+		exp  *Duration
+	}{
+		{
+			name: "Positive Integer",
+			req:  `{ "keep_alive": 42 }`,
+			exp:  &Duration{42 * time.Second},
+		},
+		{
+			name: "Positive Integer String",
+			req:  `{ "keep_alive": "42m" }`,
+			exp:  &Duration{42 * time.Minute},
+		},
+		{
+			name: "Negative Integer",
+			req:  `{ "keep_alive": -1 }`,
+			exp:  &Duration{math.MaxInt64},
+		},
+		{
+			name: "Negative Integer String",
+			req:  `{ "keep_alive": "-1m" }`,
+			exp:  &Duration{math.MaxInt64},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var dec ChatRequest
+			err := json.Unmarshal([]byte(test.req), &dec)
 			require.NoError(t, err)
 
 			assert.Equal(t, test.exp, dec.KeepAlive)

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -170,12 +170,10 @@ func RunHandler(cmd *cobra.Command, args []string) error {
 	var defaultSessionDuration = 5 * time.Minute
 	keepAlive := &api.Duration{Duration: defaultSessionDuration}
 	if envKeepAlive := os.Getenv("OLLAMA_KEEPALIVE"); envKeepAlive != "" {
-		if err = keepAlive.ParseDurationString(envKeepAlive); err != nil {
+		if err = keepAlive.FromString(envKeepAlive); err != nil {
 			return err
 		}
 	}
-
-	fmt.Println(fmt.Sprintf("current keepalive: %v", keepAlive))
 
 	opts := runOptions{
 		Model:       args[0],

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -574,10 +574,11 @@ func chat(cmd *cobra.Command, opts runOptions) (*api.Message, error) {
 	}
 
 	req := &api.ChatRequest{
-		Model:    opts.Model,
-		Messages: opts.Messages,
-		Format:   opts.Format,
-		Options:  opts.Options,
+		Model:     opts.Model,
+		Messages:  opts.Messages,
+		Format:    opts.Format,
+		Options:   opts.Options,
+		KeepAlive: opts.KeepAlive,
 	}
 
 	if err := client.Chat(cancelCtx, req, fn); err != nil {


### PR DESCRIPTION
This adds the option to have `keep_alive` set via the `OLLAMA_KEEPALIVE` environment variable. It's currently implemented for both `generate` and `chat`.
I added some tests in order to have a quick glance at how it gets parsed, since it was unpredictable without a dedicated Marshalling function.