### PR TITLE
Refactored KeepAlive Structure

### DIFF
--- a/api/types.go
+++ b/api/types.go
@@ -416,7 +416,7 @@ func WithEnvVar(name string) SessionDurationFunc {
 	return func(s *SessionDuration) error {
 		var err error
 		if envKeepAlive := os.Getenv(name); envKeepAlive != "" {
-			err = s.FromString(envKeepAlive)
+			err = s.fromString(envKeepAlive)
 		}
 		return err
 	}
@@ -441,12 +441,9 @@ func (d *SessionDuration) validate() {
 	if d.Duration < 0 {
 		d.Duration = time.Duration(math.MaxInt64)
 	}
-	fmt.Println("validated:", d.Duration)
 }
 
-func (d *SessionDuration) FromString(s string) error {
-	// currently redundant but prevents bugs
-	defer d.validate()
+func (d *SessionDuration) fromString(s string) error {
 	var err error
 	d.Duration, err = time.ParseDuration(s)
 	return err
@@ -467,7 +464,7 @@ func (d *SessionDuration) UnmarshalJSON(b []byte) (err error) {
 	case float64:
 		d.Duration = time.Duration(t * float64(time.Second))
 	case string:
-		if err = d.FromString(t); err != nil {
+		if err = d.fromString(t); err != nil {
 			return err
 		}
 	}

--- a/api/types.go
+++ b/api/types.go
@@ -34,26 +34,26 @@ func (e StatusError) Error() string {
 type ImageData []byte
 
 type GenerateRequest struct {
-	Model     string      `json:"model"`
-	Prompt    string      `json:"prompt"`
-	System    string      `json:"system"`
-	Template  string      `json:"template"`
-	Context   []int       `json:"context,omitempty"`
-	Stream    *bool       `json:"stream,omitempty"`
-	Raw       bool        `json:"raw,omitempty"`
-	Format    string      `json:"format"`
-	KeepAlive *Duration   `json:"keep_alive,omitempty"`
-	Images    []ImageData `json:"images,omitempty"`
+	Model     string           `json:"model"`
+	Prompt    string           `json:"prompt"`
+	System    string           `json:"system"`
+	Template  string           `json:"template"`
+	Context   []int            `json:"context,omitempty"`
+	Stream    *bool            `json:"stream,omitempty"`
+	Raw       bool             `json:"raw,omitempty"`
+	Format    string           `json:"format"`
+	KeepAlive *SessionDuration `json:"keep_alive,omitempty"`
+	Images    []ImageData      `json:"images,omitempty"`
 
 	Options map[string]interface{} `json:"options"`
 }
 
 type ChatRequest struct {
-	Model     string    `json:"model"`
-	Messages  []Message `json:"messages"`
-	Stream    *bool     `json:"stream,omitempty"`
-	Format    string    `json:"format"`
-	KeepAlive *Duration `json:"keep_alive,omitempty"`
+	Model     string           `json:"model"`
+	Messages  []Message        `json:"messages"`
+	Stream    *bool            `json:"stream,omitempty"`
+	Format    string           `json:"format"`
+	KeepAlive *SessionDuration `json:"keep_alive,omitempty"`
 
 	Options map[string]interface{} `json:"options"`
 }
@@ -128,9 +128,9 @@ type Runner struct {
 }
 
 type EmbeddingRequest struct {
-	Model     string    `json:"model"`
-	Prompt    string    `json:"prompt"`
-	KeepAlive *Duration `json:"keep_alive,omitempty"`
+	Model     string           `json:"model"`
+	Prompt    string           `json:"prompt"`
+	KeepAlive *SessionDuration `json:"keep_alive,omitempty"`
 
 	Options map[string]interface{} `json:"options"`
 }
@@ -400,47 +400,77 @@ func DefaultOptions() Options {
 	}
 }
 
-type Duration struct {
+type SessionDuration struct {
 	time.Duration
 }
 
-func (d *Duration) FromString(s string) error {
-	var err error
-	d.Duration, err = time.ParseDuration(s)
-	if err != nil {
+type SessionDurationFunc func(*SessionDuration) error
+
+func WithDuration(duration time.Duration) SessionDurationFunc {
+	return func(s *SessionDuration) error {
+		s.Duration = duration
+		return nil
+	}
+}
+func WithEnvVar(name string) SessionDurationFunc {
+	return func(s *SessionDuration) error {
+		var err error
+		if envKeepAlive := os.Getenv(name); envKeepAlive != "" {
+			err = s.FromString(envKeepAlive)
+		}
 		return err
 	}
+}
+
+func NewSessionDuration(opts ...SessionDurationFunc) (*SessionDuration, error) {
+	keepAlive := &SessionDuration{
+		5 * time.Minute, // default value
+	}
+	defer keepAlive.validate()
+
+	for _, opt := range opts {
+		err := opt(keepAlive)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return keepAlive, nil
+}
+
+func (d *SessionDuration) validate() {
 	if d.Duration < 0 {
 		d.Duration = time.Duration(math.MaxInt64)
 	}
-	return nil
+	fmt.Println("validated:", d.Duration)
 }
 
-func (d *Duration) MarshalJSON() ([]byte, error) {
+func (d *SessionDuration) FromString(s string) error {
+	// currently redundant but prevents bugs
+	defer d.validate()
+	var err error
+	d.Duration, err = time.ParseDuration(s)
+	return err
+}
+
+func (d *SessionDuration) MarshalJSON() ([]byte, error) {
 	return json.Marshal(d.String())
 }
 
-func (d *Duration) UnmarshalJSON(b []byte) (err error) {
+func (d *SessionDuration) UnmarshalJSON(b []byte) (err error) {
+	defer d.validate()
 	var v any
 	if err := json.Unmarshal(b, &v); err != nil {
 		return err
 	}
 
-	d.Duration = 5 * time.Minute
-
 	switch t := v.(type) {
 	case float64:
-		if t < 0 {
-			d.Duration = time.Duration(math.MaxInt64)
-		} else {
-			d.Duration = time.Duration(t * float64(time.Second))
-		}
+		d.Duration = time.Duration(t * float64(time.Second))
 	case string:
 		if err = d.FromString(t); err != nil {
 			return err
 		}
 	}
-
 	return nil
 }
 

--- a/api/types_test.go
+++ b/api/types_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -14,21 +15,21 @@ func TestKeepAliveParsingFromStruct(t *testing.T) {
 	tests := []struct {
 		name string
 		req  *ChatRequest
-		exp  *Duration
+		exp  *SessionDuration
 	}{
 		{
 			name: "Positive Duration",
 			req: &ChatRequest{
-				KeepAlive: &Duration{Duration: 42 * time.Minute},
+				KeepAlive: &SessionDuration{42 * time.Minute},
 			},
-			exp: &Duration{42 * time.Minute},
+			exp: &SessionDuration{42 * time.Minute},
 		},
 		{
 			name: "Negative Duration",
 			req: &ChatRequest{
-				KeepAlive: &Duration{Duration: -1 * time.Minute},
+				KeepAlive: &SessionDuration{-1 * time.Minute},
 			},
-			exp: &Duration{math.MaxInt64},
+			exp: &SessionDuration{math.MaxInt64},
 		},
 	}
 
@@ -49,27 +50,27 @@ func TestKeepAliveParsingFromJSON(t *testing.T) {
 	tests := []struct {
 		name string
 		req  string
-		exp  *Duration
+		exp  *SessionDuration
 	}{
 		{
 			name: "Positive Integer",
 			req:  `{ "keep_alive": 42 }`,
-			exp:  &Duration{42 * time.Second},
+			exp:  &SessionDuration{42 * time.Second},
 		},
 		{
 			name: "Positive Integer String",
 			req:  `{ "keep_alive": "42m" }`,
-			exp:  &Duration{42 * time.Minute},
+			exp:  &SessionDuration{42 * time.Minute},
 		},
 		{
 			name: "Negative Integer",
 			req:  `{ "keep_alive": -1 }`,
-			exp:  &Duration{math.MaxInt64},
+			exp:  &SessionDuration{math.MaxInt64},
 		},
 		{
 			name: "Negative Integer String",
 			req:  `{ "keep_alive": "-1m" }`,
-			exp:  &Duration{math.MaxInt64},
+			exp:  &SessionDuration{math.MaxInt64},
 		},
 	}
 
@@ -80,6 +81,44 @@ func TestKeepAliveParsingFromJSON(t *testing.T) {
 			require.NoError(t, err)
 
 			assert.Equal(t, test.exp, dec.KeepAlive)
+		})
+	}
+}
+
+func TestKeepAliveParsingFromContext(t *testing.T) {
+	tests := []struct {
+		name string
+		ctx  *gin.Context
+		exp  *SessionDuration
+	}{
+		{
+			name: "Positive Integer",
+			ctx: func() *gin.Context {
+				c := &gin.Context{}
+				d, _ := NewSessionDuration(WithDuration(42 * time.Minute))
+				c.Set("keepAlive", d)
+				return c
+			}(),
+			exp: &SessionDuration{42 * time.Minute},
+		},
+		{
+			name: "Negative Integer",
+			ctx: func() *gin.Context {
+				c := &gin.Context{}
+				d, _ := NewSessionDuration(WithDuration(-1 * time.Minute))
+				c.Set("keepAlive", d)
+				return c
+			}(),
+			exp: &SessionDuration{math.MaxInt64},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			keepAliveStr, _ := test.ctx.Get("keepAlive")
+			keepAlive := keepAliveStr.(*SessionDuration)
+
+			assert.Equal(t, test.exp, keepAlive)
 		})
 	}
 }

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -167,10 +167,13 @@ func RunHandler(cmd *cobra.Command, args []string) error {
 
 	interactive := true
 
-	var defaultSessionDuration = 5 * time.Minute
-	keepAlive := &api.Duration{Duration: defaultSessionDuration}
-	if envKeepAlive := os.Getenv("OLLAMA_KEEPALIVE"); envKeepAlive != "" {
-		if err = keepAlive.FromString(envKeepAlive); err != nil {
+	// leaves it nil if unset. will use the default server behavior
+	var keepAlive *api.SessionDuration
+	if os.Getenv("OLLAMA_KEEPALIVE") != "" {
+		keepAlive, err = api.NewSessionDuration(
+			api.WithEnvVar("OLLAMA_KEEPALIVE"),
+		)
+		if err != nil {
 			return err
 		}
 	}
@@ -483,7 +486,7 @@ type runOptions struct {
 	Images      []api.ImageData
 	Options     map[string]interface{}
 	MultiModal  bool
-	KeepAlive   *api.Duration
+	KeepAlive   *api.SessionDuration
 }
 
 type displayResponseState struct {

--- a/server/routes.go
+++ b/server/routes.go
@@ -35,7 +35,8 @@ import (
 var mode string = gin.DebugMode
 
 type Server struct {
-	WorkDir string
+	WorkDir   string
+	KeepAlive *api.SessionDuration
 }
 
 func init() {
@@ -62,11 +63,11 @@ var loaded struct {
 	*api.Options
 }
 
-var defaultSessionDuration = 5 * time.Minute
-
 // load a model into memory if it is not already loaded, it is up to the caller to lock loaded.mu before calling this function
-func load(c *gin.Context, model *Model, opts api.Options, sessionDuration time.Duration) error {
+func load(c *gin.Context, model *Model, opts api.Options, keepAlive *api.SessionDuration) error {
 	workDir := c.GetString("workDir")
+	/* keepAliveStr, _ := c.Get("keepAlive")
+	keepAlive := keepAliveStr.(*api.SessionDuration) */
 
 	needLoad := loaded.runner == nil || // is there a model loaded?
 		loaded.ModelPath != model.ModelPath || // has the base model changed?
@@ -99,10 +100,10 @@ func load(c *gin.Context, model *Model, opts api.Options, sessionDuration time.D
 		loaded.Options = &opts
 	}
 
-	loaded.expireAt = time.Now().Add(sessionDuration)
+	loaded.expireAt = time.Now().Add(keepAlive.Duration)
 
 	if loaded.expireTimer == nil {
-		loaded.expireTimer = time.AfterFunc(sessionDuration, func() {
+		loaded.expireTimer = time.AfterFunc(keepAlive.Duration, func() {
 			loaded.mu.Lock()
 			defer loaded.mu.Unlock()
 
@@ -120,7 +121,7 @@ func load(c *gin.Context, model *Model, opts api.Options, sessionDuration time.D
 		})
 	}
 
-	loaded.expireTimer.Reset(sessionDuration)
+	loaded.expireTimer.Reset(keepAlive.Duration)
 	return nil
 }
 
@@ -201,14 +202,13 @@ func GenerateHandler(c *gin.Context) {
 		return
 	}
 
-	var sessionDuration time.Duration
-	if req.KeepAlive == nil {
-		sessionDuration = defaultSessionDuration
-	} else {
-		sessionDuration = req.KeepAlive.Duration
+	keepAliveServer, _ := c.Get("keepAliveServer")
+	keepAlive := keepAliveServer.(*api.SessionDuration)
+	if keepAliveClient := req.KeepAlive; keepAliveClient != nil {
+		keepAlive = keepAliveClient
 	}
 
-	if err := load(c, model, opts, sessionDuration); err != nil {
+	if err := load(c, model, opts, keepAlive); err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
 	}
@@ -281,8 +281,8 @@ func GenerateHandler(c *gin.Context) {
 
 		fn := func(r llm.PredictResult) {
 			// Update model expiration
-			loaded.expireAt = time.Now().Add(sessionDuration)
-			loaded.expireTimer.Reset(sessionDuration)
+			loaded.expireAt = time.Now().Add(keepAlive.Duration)
+			loaded.expireTimer.Reset(keepAlive.Duration)
 
 			// Build up the full response
 			if _, err := generated.WriteString(r.Content); err != nil {
@@ -420,14 +420,13 @@ func EmbeddingHandler(c *gin.Context) {
 		return
 	}
 
-	var sessionDuration time.Duration
-	if req.KeepAlive == nil {
-		sessionDuration = defaultSessionDuration
-	} else {
-		sessionDuration = req.KeepAlive.Duration
+	keepAliveServer, _ := c.Get("keepAliveServer")
+	keepAlive := keepAliveServer.(*api.SessionDuration)
+	if keepAliveClient := req.KeepAlive; keepAliveClient != nil {
+		keepAlive = keepAliveClient
 	}
 
-	if err := load(c, model, opts, sessionDuration); err != nil {
+	if err := load(c, model, opts, keepAlive); err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
 	}
@@ -905,8 +904,16 @@ func NewServer() (*Server, error) {
 		return nil, err
 	}
 
+	keepAlive, err := api.NewSessionDuration(
+		api.WithEnvVar("OLLAMA_DEFAULT_KEEPALIVE"),
+	)
+	if err != nil {
+		return nil, err
+	}
+
 	return &Server{
-		WorkDir: workDir,
+		WorkDir:   workDir,
+		KeepAlive: keepAlive,
 	}, nil
 }
 
@@ -935,6 +942,7 @@ func (s *Server) GenerateRoutes() http.Handler {
 		cors.New(config),
 		func(c *gin.Context) {
 			c.Set("workDir", s.WorkDir)
+			c.Set("keepAliveServer", s.KeepAlive)
 			c.Next()
 		},
 	)
@@ -1153,14 +1161,13 @@ func ChatHandler(c *gin.Context) {
 		return
 	}
 
-	var sessionDuration time.Duration
-	if req.KeepAlive == nil {
-		sessionDuration = defaultSessionDuration
-	} else {
-		sessionDuration = req.KeepAlive.Duration
+	keepAliveServer, _ := c.Get("keepAliveServer")
+	keepAlive := keepAliveServer.(*api.SessionDuration)
+	if keepAliveClient := req.KeepAlive; keepAliveClient != nil {
+		keepAlive = keepAliveClient
 	}
 
-	if err := load(c, model, opts, sessionDuration); err != nil {
+	if err := load(c, model, opts, keepAlive); err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
 	}
@@ -1211,8 +1218,8 @@ func ChatHandler(c *gin.Context) {
 
 		fn := func(r llm.PredictResult) {
 			// Update model expiration
-			loaded.expireAt = time.Now().Add(sessionDuration)
-			loaded.expireTimer.Reset(sessionDuration)
+			loaded.expireAt = time.Now().Add(keepAlive.Duration)
+			loaded.expireTimer.Reset(keepAlive.Duration)
 
 			resp := api.ChatResponse{
 				Model:     req.Model,

--- a/server/routes.go
+++ b/server/routes.go
@@ -66,8 +66,6 @@ var loaded struct {
 // load a model into memory if it is not already loaded, it is up to the caller to lock loaded.mu before calling this function
 func load(c *gin.Context, model *Model, opts api.Options, keepAlive *api.SessionDuration) error {
 	workDir := c.GetString("workDir")
-	/* keepAliveStr, _ := c.Get("keepAlive")
-	keepAlive := keepAliveStr.(*api.SessionDuration) */
 
 	needLoad := loaded.runner == nil || // is there a model loaded?
 		loaded.ModelPath != model.ModelPath || // has the base model changed?
@@ -904,7 +902,7 @@ func NewServer() (*Server, error) {
 		return nil, err
 	}
 
-	keepAlive, err := api.NewSessionDuration(
+	keepAliveServer, err := api.NewSessionDuration(
 		api.WithEnvVar("OLLAMA_DEFAULT_KEEPALIVE"),
 	)
 	if err != nil {
@@ -913,7 +911,7 @@ func NewServer() (*Server, error) {
 
 	return &Server{
 		WorkDir:   workDir,
-		KeepAlive: keepAlive,
+		KeepAlive: keepAliveServer,
 	}, nil
 }
 


### PR DESCRIPTION
Refactored `keep_alive` into a `SessionDuration` struct, this allows reading from customized environment variables such as `OLLAMA_DEFAULT_KEEPALIVE` and `OLLAMA_KEEPALIVE` to manually control server-side and client-side values respectively.
While a default value is always present server-side, it's made optional for clients. However when a client specifies a duration it will always override the server's configuration for that particular request.

Example:

| Server       | Client | Result |
| ------------ | ------ | ------ |
| 5m (default)   | nil    | 5m     |
| 5m (default)   | 10m    | 10m    |
| 30s          | 5m     | 5m     |